### PR TITLE
ci: add prose linting with vale

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,14 @@
+name: prose linting
+on:
+  pull_request:
+
+jobs:
+  lint-docs:
+    name: Lint documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          files: content/en/docs
+          fail_on_error: true

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = suggestion
+Packages = Hugo
+Vocab = coco
+
+[*.md]
+BasedOnStyles = Vale

--- a/styles/config/vocabularies/coco/accept.txt
+++ b/styles/config/vocabularies/coco/accept.txt
@@ -1,0 +1,4 @@
+Rivos
+Skopeo
+untrusted
+VM


### PR DESCRIPTION
This is useful to smoothen the review of submissions and the overall quality of the content.

Vale is able to use certain comprehensive style guides (e.g. Redhat, Microsoft, Google). This PR just uses merely the base check, which already produces some good findings.

We can decide on a more opinionated style guide later.