### PR TITLE
demos: fix SSH and operator demo documentation

### DIFF
--- a/content/en/docs/demos/ssh-demo/index.md
+++ b/content/en/docs/demos/ssh-demo/index.md
@@ -10,21 +10,17 @@ tags:
 - demo
 ---
 
-{{% alert title="Warning" color="warning" %}}
-TODO: This was copied with few adaptations from here: <https://github.com/confidential-containers/confidential-containers/tree/main/demos/ssh-demo>. This needs to be tested and verified if the instructions still work and needs a rework.
-{{% /alert %}}
-
 To demonstrate confidential containers capabilities, we run a pod with SSH public key authentication.
 
 Compared to the execution of and login to a shell on a pod, an SSH connection is cryptographically secured and requires a private key. It cannot be established by unauthorized parties, such as someone who controls the node. The container image contains the SSH host key that can be used for impersonating the host we will connect to. Because this container image is encrypted, and the key to decrypting this image is only provided in measurable ways (e.g. attestation or encrypted initrd), and because the pod/guest memory is protected, even someone who controls the node cannot steal this key.
 
 ## Using a pre-provided container image
 
-If you would rather build the image with your own keys, skip to [Building the container image](#building-the-container-image). The [operator](/demos/operator-demo) can be used to set up a compatible runtime.
+If you would rather build the image with your own keys, skip to [Building the container image](#building-the-container-image). The [operator](/docs/demos/ccv0-operator-demo) can be used to set up a compatible runtime.
 
 A demo image is provided at [docker.io/katadocker/ccv0-ssh](https://hub.docker.com/r/katadocker/ccv0-ssh).
-It is encrypted with [Attestation Agent](https://github.com/confidential-containers/attestation-agent)'s [offline file system key broker](https://github.com/confidential-containers/attestation-agent/tree/64c12fbecfe90ba974d5fe4896bf997308df298d/src/kbc_modules/offline_fs_kbc) and [`aa-offline_fs_kbc-keys.json`](./aa-offline_fs_kbc-keys.json) as its key file.
-The private key for establishing an SSH connection to this container is given in [`ccv0-ssh`](./ccv0-ssh).
+It is encrypted with [Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent)'s [offline file system key broker](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent/kbc/src/offline_fs_kbc) and [`aa-offline_fs_kbc-keys.json`](./includes/aa-offline_fs_kbc-keys.json) as its key file.
+The private key for establishing an SSH connection to this container is given in [`ccv0-ssh`](./includes/ccv0-ssh).
 To use it with SSH, its permissions should be adjusted: `chmod 600 ccv0-ssh`.
 The host key fingerprint is `SHA256:wK7uOpqpYQczcgV00fGCh+X97sJL3f6G1Ku4rvlwtR0`.
 
@@ -36,7 +32,7 @@ Continue at [Connecting to the guest](#connecting-to-the-guest).
 ## Building the container image
 
 The image built should be encrypted.
-To receive a decryption key at run time, the Confidential Containers project utilizes the [Attestation Agent](https://github.com/confidential-containers/attestation-agent).
+To receive a decryption key at run time, the Confidential Containers project utilizes the [Attestation Agent](https://github.com/confidential-containers/guest-components/tree/main/attestation-agent).
 
 ### Generating SSH keys
 
@@ -48,11 +44,11 @@ generates an SSH key `ccv0-ssh` and the correspondent public key `ccv0-ssh.pub`.
 
 ### Building the image
 
-The provided [`Dockerfile`](./Dockerfile) expects `ccv0-sh.pub` to exist.
+The provided [`Dockerfile`](./includes/Dockerfile) expects `ccv0-sh.pub` to exist.
 Using Docker, you can build with
 
 ```bash
-docker build -t ccv0-ssh .
+docker build --progress=plain -t ccv0-ssh .
 ```
 
 Alternatively, Buildah can be used (`buildah build` or formerly `buildah bud`).
@@ -60,7 +56,7 @@ The SSH host key fingerprint is displayed during the build.
 
 ## Connecting to the guest
 
-A [Kubernetes YAML file](./k8s-cc-ssh.yaml) specifying the [`kata`](https://github.com/kata-containers/kata-containers) runtime is included.
+A [Kubernetes YAML file](./includes/k8s-cc-ssh.yaml) specifying the [`kata`](https://github.com/kata-containers/kata-containers) runtime is included.
 If you use a [self-built image](#building-the-container-image), you should replace the image specification with the image you built.
 The default tag points to an `amd64` image, an `s390x` tag is also available.
 With common CNI setups, on the same host, with the service running, you can connect via SSH with
@@ -72,4 +68,4 @@ ssh -i ccv0-ssh root@$(kubectl get service ccv0-ssh -o jsonpath="{.spec.clusterI
 You will be prompted about whether the host key fingerprint is correct.
 This fingerprint should match the one specified above/displayed in the Docker build.
 
-`crictl`-compatible [sandbox](./cri-sandbox-config.yaml) and [container](./cri-container-config.yaml) configurations are also included, which forward the pod SSH port (22) to 2222 on the host (use the `-p` flag in SSH).
+`crictl`-compatible [sandbox](./includes/cri-sandbox-config.yaml) and [container](./includes/cri-container-config.yaml) configurations are also included, which forward the pod SSH port (22) to 2222 on the host (use the `-p` flag in SSH).


### PR DESCRIPTION
- Fix broken links
- Update links to old branches to new branches
- Add worker node label command
- FIx typos
- Add `--progress=plain` to `docker build` so the user can see the key fingerprint
- Remove the "adaptation" warning because they have been tested and verified now

I haven't tried the kcli setup example nor the crictl configuration for port forwarding.

The `katadocker/ccv0-ssh` demo image didn't work for me as explained in the instructions because they don't explain how to set up an attestation-agent. We can address that part in a follow-up PR.