### PR TITLE
Add Analytics

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -39,7 +39,7 @@ module:
 services:
   googleAnalytics:
   # Comment out the next line to disable GA tracking. Also disables the feature described in params.ui.feedback
-  id: "UA-00000000-0"
+  id: "G-T5F3PD1708"
 
 markup:
   goldmark:


### PR DESCRIPTION
Setup Google analytics on the website. Before we start a big push on website content, let's setup analytics so we know if anyone is looking at the site and which pages they are most interested in. 

Unfortunately we don't have a great way to hook google analytics into our github organization. This property is linked to my google account, but it can be shared with anyone else's google account. Lmk if there is a better way to handle this.