### PR TITLE
Add support for links to headers and subheaders

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+{{ template "_default/_markup/td-render-heading.html" . }}


### PR DESCRIPTION
This lets us share links to specific header sections within the docs, which is a nice-to-have.