### PR TITLE
Enable basic search support across the site

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -35,7 +35,6 @@ module:
   - path: github.com/google/docsy
   - path: github.com/google/docsy/dependencies
 
-# TODO: Get a google analytics tracking id for this to work.
 services:
   googleAnalytics:
   # Comment out the next line to disable GA tracking. Also disables the feature described in params.ui.feedback
@@ -121,12 +120,10 @@ params:
   # gcs_engine_id: d72aa9b2712488cc3
 
   # # Enable Algolia DocSearch
-  # # TODO: Should we enable this instead?
   # algolia_docsearch: false
 
   # # Enable Lunr.js offline search
-  # # TODO: Should we enable this instead?
-  # offlineSearch: false
+  offlineSearch: true
 
   # # Enable syntax highlighting and copy buttons on code blocks with Prism
   # # TODO: Should we enable this?


### PR DESCRIPTION
This uses the Lunr.js functionality that's part of our website framework. It's an offline javascript-based search (not using Google, for example). Seems to work fine.

It adds a search bar above the navigation on the left-hand side, and it adds a search bar in the top right. The one above the navigation bar can be disabled if we want, but I left it there.