### PR TITLE
config: make description more verbose

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -12,7 +12,7 @@ languages:
     weight: 1
     params:
       title: Confidential Containers
-      description: Documentation for Confidential Containers
+      description: Cloud Native Confidential Computing; Run Confidential Containers on Kubernetes
 
 enableRobotsTXT: true
 enableEmoji: true


### PR DESCRIPTION
Make description more verbose to capture scope of project.

Really, this is for SEO. Hugo already populates various metadata tags, so we don't need to (and shouldn't) do too much, but maybe this will help.

@ariel-adam 