### PR TITLE
docs: fix typos

### DIFF
--- a/content/en/docs/architecture/design-overview.md
+++ b/content/en/docs/architecture/design-overview.md
@@ -176,7 +176,7 @@ Confidential Containers integrates many components. Here is a brief overview of 
 | Operator  | operator | Installs Confidential Containers |
 | Kata Shim | kata-containers/kata-containers | Starts PodVM and proxies requests to Kata Agent |
 | Kata Agent | kata-containers/kata-containers | Sets up and runs the workload inside of a VM |
-| image-rs | guest-componenents | Downloads and unpacks container images |
+| image-rs | guest-components | Downloads and unpacks container images |
 | ocicrypt-rs | guest-components | Decrypts encrypted container layers |
 | confidential-data-hub | guest-components | Handles secret resources |
 | attestation-agent | guest-components | Attests guest |
@@ -193,7 +193,7 @@ Confidential Containers integrates many components. Here is a brief overview of 
 Many of the above components depend on each other either directly in the source,
 during packaging, or at runtime.
 The basic premise is that the operator deploys a special configuration of Kata containers
-that uses a rootfs (build by the Kata CI) that includes the guest components.
+that uses a rootfs (built by the Kata CI) that includes the guest components.
 This diagram shows these relationships in more detail.
 The diagram does not capture runtime interactions.
 

--- a/content/en/docs/architecture/trust-model/trust-model.md
+++ b/content/en/docs/architecture/trust-model/trust-model.md
@@ -19,7 +19,7 @@ that the untrusted host cannot access guest data or manipulate guest control flo
 Confidential Containers maps pods to confidential VMs, meaning that everything inside a pod is
 within an enclave. In addition to the workload pod, the guest also contains helper processes
 and daemons to setup and control the pod.
-These include the `kata-agent`, and guest components as described in the architecture section.
+These include the `kata-agent` and guest components as described in the architecture section.
 
 More specifically, the guest is defined as four components.
 - Guest firmware


### PR DESCRIPTION
Fix a couple minor typos in the architecture pages.