### PR TITLE
docs: fix node role typo in cluster setup

### DIFF
--- a/content/en/docs/getting-started/prerequisites/software.md
+++ b/content/en/docs/getting-started/prerequisites/software.md
@@ -13,7 +13,7 @@ A cluster must be installed before running the operator.
 Many different clusters can be used but they should meet the following requirements.
 - The minimum Kubernetes version is 1.24
 - Cluster must use `containerd` or `cri-o`.
-- At least one node has the label `node-role.kubernetes.io/worker=`.
+- At least one node has the label `node.kubernetes.io/worker`.
 - SELinux is not enabled.
 
 If you use Minikube or Kind to setup your cluster, you will only be able to use


### PR DESCRIPTION
This is a somewhat calamitous typo. Unless you set the correct label, the CR won't do anything.

Also, remove the equals at the end since that is not part of the label.