### PR TITLE
overview: remove SEV-ES support

### DIFF
--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -26,7 +26,6 @@ On bare metal Confidential Containers supports the following platforms:
 | Intel TDX | Yes | Yes |
 | Intel SGX | Yes | No |
 | AMD SEV-SNP | Yes | Yes |
-| AMD SEV(-ES) | No | Yes |
 | IBM Secure Execution | Yes | Yes |
 
 Confidential Containers can also be deployed in a cloud environment using the


### PR DESCRIPTION
We don't support SEV-ES anymore, so let's remove it from our platform information table.