### PR TITLE
Update the instructions for installing Trustee with docker compose

### DIFF
--- a/content/en/docs/attestation/installation/docker.md
+++ b/content/en/docs/attestation/installation/docker.md
@@ -38,6 +38,20 @@ openssl genpkey -algorithm ed25519 > kbs/config/private.key
 openssl pkey -in kbs/config/private.key -pubout -out kbs/config/public.pub
 ```
 
+#### Debug Mode (Optional)
+
+To enable additional debug information, you can set the `RUST_LOG` environment variable.
+
+First, create a file called `debug.env`.
+```bash
+RUST_LOG=debug
+```
+
+Then, you can run Trustee with an additional argument.
+```bash
+docker-compose --env-file debug.env up
+```
+
 ### Uninstall
 
 Stop Trustee.


### PR DESCRIPTION
Now the admin keypair will be automatically generated and we have an easy way to enable debug. Add this to the docs.