### PR TITLE
Getting Started Guide: Changes representing SNP kernel update

### DIFF
--- a/content/en/docs/getting-started/prerequisites/hardware/snp.md
+++ b/content/en/docs/getting-started/prerequisites/hardware/snp.md
@@ -12,7 +12,7 @@ tags:
 
 The host BIOS and kernel must be capable of supporting AMD SEV-SNP and the host must be configured accordingly.
 
-The latest SEV Firmware version is available on AMD's [SEV Developer Webpage](https://www.amd.com/en/developer/sev.html). It can also be updated via a platform OEM BIOS update.
+The SEV Firmware version must be at least version 1.55 in order to have at least version 3 of the Attestation Report. The latest SEV Firmware version is available on AMD's [SEV Developer Webpage](https://www.amd.com/en/developer/sev.html). It can also be updated via a platform OEM BIOS update.
 
 The host kernel must be equal to or later than upstream version [6.16.1](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git).
 

--- a/content/en/docs/getting-started/prerequisites/hardware/snp.md
+++ b/content/en/docs/getting-started/prerequisites/hardware/snp.md
@@ -14,7 +14,7 @@ The host BIOS and kernel must be capable of supporting AMD SEV-SNP and the host 
 
 The latest SEV Firmware version is available on AMD's [SEV Developer Webpage](https://www.amd.com/en/developer/sev.html). It can also be updated via a platform OEM BIOS update.
 
-The host kernel must be equal to or later than upstream version [6.11](https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.11.tar.xz).
+The host kernel must be equal to or later than upstream version [6.16.1](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git).
 
 To build just the upstream compatible host kernel, use the Confidential Containers fork of [AMDESE AMDSEV](https://github.com/confidential-containers/amdese-amdsev/tree/amd-snp-202501150000). Individual components can be built by running the following command:
 

--- a/content/en/docs/getting-started/prerequisites/hardware/snp.md
+++ b/content/en/docs/getting-started/prerequisites/hardware/snp.md
@@ -21,5 +21,3 @@ To build just the upstream compatible host kernel, use the Confidential Containe
 ```
 ./build.sh kernel host --install
 ```
-
-Additionally, [sev-utils](https://github.com/amd/sev-utils/blob/coco-202501150000/docs/snp.md) can be used to install the required host kernel, but it will unnecessarily build AMD compatible guest kernel, OVMF, and QEMU components as these packages are already packaged with Kata. The additional components can be used with the script utility to test launch and attest a base QEMU SNP guest.


### PR DESCRIPTION
Making changes to represent the changes to the recommended SNP kernel (v6.16.1).

Removing references to sev-utils as it's been deprecated.

To be merged after [PR #4](https://github.com/confidential-containers/amdese-amdsev/pull/4) in CoCo/amdese-amdsev.