### PR TITLE
link: updating link to amdese-amdsev

### DIFF
--- a/content/en/docs/getting-started/prerequisites/hardware/snp.md
+++ b/content/en/docs/getting-started/prerequisites/hardware/snp.md
@@ -16,7 +16,7 @@ The SEV Firmware version must be at least version 1.55 in order to have at least
 
 The host kernel must be equal to or later than upstream version [6.16.1](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git).
 
-To build just the upstream compatible host kernel, use the Confidential Containers fork of [AMDESE AMDSEV](https://github.com/confidential-containers/amdese-amdsev/tree/amd-snp-202501150000). Individual components can be built by running the following command:
+To build just the upstream compatible host kernel, use the Confidential Containers fork of [AMDESE AMDSEV](https://github.com/confidential-containers/amdese-amdsev/tree/amd-snp-202511200000). Individual components can be built by running the following command:
 
 ```
 ./build.sh kernel host --install


### PR DESCRIPTION
Updating the link to the latest tag
of amdese-amdsev that includes commands
to install kernel v6.16.1.