### PR TITLE
signed images: specify cosign version

### DIFF
--- a/content/en/docs/features/signed-images.md
+++ b/content/en/docs/features/signed-images.md
@@ -28,7 +28,6 @@ approach. In any case, the general approach is to
 3. Update the [KBS](/docs/attestation/key-broker-service) with the public
    signature key and a security policy.
 
-
 ## Creating an Image
 
 ### Creating Keys
@@ -106,8 +105,27 @@ docker build \
   -f <your_dockerfile> \
   .
 docker push ghcr.io/$(COCO_PKG):cosign-sig
+```
+
+If using `cosign` version `v3.0.x`, use the following command to sign the image:
+
+```shell
+cosign sign --new-bundle-format=false \
+  --use-signing-config=false \
+  --key ./cosign.key \
+  ghcr.io/${COCO_PKG}:cosign-sig
+```
+
+If using `cosign` version `>= v2.0` and `< v3.0`, use the following command to sign the image:
+
+```shell
 cosign sign --key ./cosign.key ghcr.io/${COCO_PKG}:cosign-sig
 ```
+
+{{% alert title="Note" color="primary" %}}
+cosign versions `v2.0.x` and `v2.1.x` have a different private key format from `>= v2.2.0`.
+{{% /alert %}}
+
 {{% /tab %}}
 
 {{% tab header="Simple Signing - skopeo" %}}


### PR DESCRIPTION
New version (3) of cosign have different default behavior from the v2.x series. Specifically, v2.x generates a legacy simple signing payload as an artifact in the registry, while v3 uses bundle v0.3 and OCI v1.1  (referrer) mechanism. Current image signature verification behavior in CoCo only supports the legacy way.
    
Luckily, v3 provides a way to sign images in the legacy way.
    
This commit provides detailed version compatibility guidance:
- For cosign v3.0.x: use specific flags (--new-bundle-format=false, etc.)
- For cosign v2.0 to v3.0: use standard cosign sign command
- Note about private key format differences between v2.0.x/v2.1.x and >=v2.2.0