### PR TITLE
Init-data: Remove incorrect CreateContainerRequest policy example

### DIFF
--- a/content/en/docs/features/initdata.md
+++ b/content/en/docs/features/initdata.md
@@ -70,7 +70,7 @@ default ExecProcessRequest := false
 # Block container creation by default
 default CreateContainerRequest := false
 
-# Only allow specific image digests
+# Allow any image if nginx is also specified
 CreateContainerRequest if {
 	some storage in input.storages
 	storage.source == "docker.io/library/nginx@sha256:e56797eab4a5300158cc015296229e13a390f82bfc88803f45b08912fd5e3348"
@@ -239,7 +239,7 @@ default ExecProcessRequest := false
 # Block container creation by default
 default CreateContainerRequest := false
 
-# Only allow specific image digests
+# Allow any image if nginx is also specified
 CreateContainerRequest if {
     some storage in input.storages
     storage.source == "docker.io/library/nginx@sha256:e56797eab4a5300158cc015296229e13a390f82bfc88803f45b08912fd5e3348"

--- a/content/en/docs/features/initdata.md
+++ b/content/en/docs/features/initdata.md
@@ -67,14 +67,8 @@ default StatsContainerRequest := true
 # Block exec by default
 default ExecProcessRequest := false
 
-# Block container creation by default
-default CreateContainerRequest := false
-
-# Only allow specific image digests
-CreateContainerRequest if {
-	some storage in input.storages
-	storage.source == "docker.io/library/nginx@sha256:e56797eab4a5300158cc015296229e13a390f82bfc88803f45b08912fd5e3348"
-}
+# Allow creating any container by default
+default CreateContainerRequest := true
 
 # Optionally allow specific commands
 ExecProcessRequest if {
@@ -236,14 +230,8 @@ default StatsContainerRequest := true
 # Block exec by default
 default ExecProcessRequest := false
 
-# Block container creation by default
-default CreateContainerRequest := false
-
-# Only allow specific image digests
-CreateContainerRequest if {
-    some storage in input.storages
-    storage.source == "docker.io/library/nginx@sha256:e56797eab4a5300158cc015296229e13a390f82bfc88803f45b08912fd5e3348"
-}
+# Allow creating any container by default
+default CreateContainerRequest := true
 
 # Optionally allow specific commands
 ExecProcessRequest if {


### PR DESCRIPTION
The current code comment in the policy suggests that the policy restricts which images can be run, but that's not what's actually encoded in the policy. This PR just removes the example.