### PR TITLE
docs: Update GPU support

### DIFF
--- a/content/en/docs/attestation/policies/_index.md
+++ b/content/en/docs/attestation/policies/_index.md
@@ -225,16 +225,23 @@ For instance, the init-data could be used to assign each guest a UUID or a workl
 Attestation service policies are what the attestation service uses to calculate EAR trust vectors
 based on the TCB claims extracted from the hardware evidence by the verifiers.
 Essentially the attestation service policy defines which parts of the evidence are important
-and how the evidence should be compared to reference values.
+and how the evidence should be compared to reference values. Trustee supports multiple attestation 
+service policies for different types of devices. When you are using multiple devices in the same pod,
+like a CPU and a GPU, we call that composite evidence.
 
-The default attestation service policy already defines this relationship for TDX and SNP guests
+The default attestation service CPU policy already defines this relationship for TDX and SNP guests
 booted by the Kata shim and running Kata guests.
 If you are using Confidential Containers with these platforms you probably do not need
 to change this policy.
+
+GPU and composite flows use the
+[default GPU policy](https://github.com/confidential-containers/trustee/blob/main/attestation-service/src/ear_token/ear_default_policy_gpu.rego).
+If you are using NVIDIA Confidential Computing GPUs you probably do not need to change this policy.
+
 If you are using Trustee to boot different types of guests, you might want to adjust the attestation service policy
 to capture your TCB.
 
 Either way, you'll need to provide the reference values that the attestation service policy expects.
 Take a look at the [default CPU policy](https://github.com/confidential-containers/trustee/blob/main/attestation-service/src/ear_token/ear_default_policy_cpu.rego)
-to see which values are expected.
+to see which values are expected for CPUs.
 You only need to provision the reference values for the platform that you are using.

--- a/content/en/docs/getting-started/securing-workloads.md
+++ b/content/en/docs/getting-started/securing-workloads.md
@@ -179,7 +179,9 @@ Attestation service policies define **how hardware evidence is evaluated** - wha
 **Learn more:** [Attestation Service Policies](../../attestation/policies/#attestation-service-policies)
 
 {{% alert title="Default Policies" color="success" %}}
-CoCo ships with sensible default attestation policies for TDX and SNP. For most users, you only need to provide reference values - the policy is already configured appropriately.
+CoCo ships with sensible default attestation policies for TDX and SNP CPU guests, as well as for
+NVIDIA Confidential Computing GPUs.
+For most users, you only need to provide reference values - the policy is already configured appropriately.
 {{% /alert %}}
 
 ## Additional Security Features

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -28,6 +28,20 @@ On bare metal Confidential Containers supports the following platforms:
 | AMD SEV-SNP | Yes | Yes |
 | IBM Secure Execution | Yes | Yes |
 
+### Accelerators
+
+| Accelerator | Single Device Passthrough | Multi Device Passthrough |
+| --- | --- | --- |
+| Hygon DCU | Yes | No | 
+| NVIDIA Hopper | Yes | Protected PCIe |
+| NVIDIA RTX Pro 6000 BSE | Yes | Yes |
+| NVIDIA Blackwell | Yes | Yes |
+
+NVIDIA Multi-Passthrough requires assigning all GPUs on a host to one pod.
+NVIDIA Protected PCIe additionally requires listing the NVIDIA NVLink switches in the pod.
+
+### Clouds
+
 Confidential Containers can also be deployed in a cloud environment using the
 `cloud-api-adaptor`.
 The following platforms are supported.
@@ -42,6 +56,8 @@ The following platforms are supported.
 | TDX | GCP | Under development |
 | None | LibVirt | For local testing |
 
+### Attestation 
+
 Confidential Containers provides an attestation and key-management engine, called Trustee
 which is able to attest the following platforms:
 
@@ -55,6 +71,7 @@ which is able to attest the following platforms:
 | IBM Secure Execution |
 | ARM CCA | 
 | Hygon CSV |
+| NVIDIA GPU |
 
 Trustee can be used with Confidential Containers or to attest standalone confidential guests.
 See `Attestation` section for more information.

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -21,12 +21,11 @@ attesting them, and provisioning secrets.
 
 On bare metal Confidential Containers supports the following platforms: 
 
-| Platform | Supports Attestation | Uses Kata |
-| -------- | -------------------- | --------- |
-| Intel TDX | Yes | Yes |
-| Intel SGX | Yes | No |
-| AMD SEV-SNP | Yes | Yes |
-| IBM Secure Execution | Yes | Yes |
+| Platform | Supports Attestation |
+| -------- | -------------------- |
+| Intel TDX | Yes |
+| AMD SEV-SNP | Yes |
+| IBM Secure Execution | Yes |
 
 ### Accelerators
 

--- a/styles/config/vocabularies/coco/accept.txt
+++ b/styles/config/vocabularies/coco/accept.txt
@@ -34,9 +34,11 @@ LLM[s]
 [Nn]amespace
 [nN]ginx
 [nN]odeport
+NVLink
 OCI
 ocicrypt
 oras
+PCI[eE]
 PCR
 Peerpod
 Peer[pP]ods
@@ -103,7 +105,7 @@ subproject
 subprojects
 [rR]ustfmt
 rebase
-passthrough
+[pP]assthrough
 [sS]napshotter
 [nN]ydus
 runtimes


### PR DESCRIPTION
GPUs were missing from the overview page.
Also updated some text to clarify CPU v GPU. 
And remove leftover SGX reference. That also obviates the need for the Kata column.