### PR TITLE
Misc doc updates

### DIFF
--- a/content/en/docs/attestation/coco-setup/_index.md
+++ b/content/en/docs/attestation/coco-setup/_index.md
@@ -12,6 +12,9 @@ tags:
 
 If you are using Trustee with Confidential Containers, you'll need to point
 your CoCo workload to your Trustee.
+You can do this with an annotation on your workload, or via init-data.
+
+## Annotation
 
 In your pod definition, add the following annotation.
 ```yaml
@@ -42,4 +45,30 @@ spec:
   runtimeClassName: kata-qemu-coco-dev
 ```
 
-The Trustee address can also be configured via init data.
+## Init-Data
+
+The KBS URI can be set via Init-Data.
+Add the KBS URI to both the Attestation Agent config file (`aa.toml`)
+and to the CDH config file (`cdh.toml`).
+In most cases the CDH and the AA should use the same KBS.
+
+```toml
+version = "0.1.0"
+algorithm = "sha384"
+
+[data]
+
+"aa.toml" = '''
+[token_configs.kbs]
+url = "http://<kbs-ip>:<kbs-port>"
+'''
+
+"cdh.toml" = '''
+[kbc]
+name = "cc_kbc"
+url = "http://<kbs-ip>:<kbs-port>"
+'''
+```
+
+See [Init-Data](../features/initdata) page for instructions on how to attach
+the Init-Data to a workload.

--- a/content/en/docs/attestation/installation/docker.md
+++ b/content/en/docs/attestation/installation/docker.md
@@ -52,9 +52,27 @@ Then, you can run Trustee with an additional argument.
 docker compose --env-file debug.env up
 ```
 
+### Advanced Setup
+
+Docker Compose mounts Trustee configuration files from the Trustee repository itself.
+Specifically, the KBS configuration file is located in `kbs/config/docker-compose/kbs-config.toml`,
+the Attestation Service configuration is in `/kbs/config/as-config.json`,
+and the RVPS configuration is in `/kbs/config/rvps.json`.
+
+These configuration files are read at Trustee startup. If you edit them, restart Trustee (`docker compose restart`).
+The configuration options are described [here](https://github.com/confidential-containers/trustee/blob/main/kbs/docs/config.md) and [here](https://github.com/confidential-containers/trustee/blob/main/attestation-service/docs/config.md).
+
+#### Advanced Settings
+
+Some advanced settings that you may want to enable include:
+* **HTTPS** HTTPS can be enabled via the KBS configuration file. HTTPS provides an additional level of security on top of the KBS protocol and should be enabled in production environments.
+* **Slim Attestation Token** Guests with many devices can create large attestation tokens. In some cases this will outgrow HTTP header limits. When attesting guests with many devices (such as NVIDIA PPCIE), set `verbose_token` to false in the AS config file.
+* **Token Duration** The lifetime/duration of the attestation token can be set via the `duration_min` field of the AS config.
+
 ### Uninstall
 
 Stop Trustee.
 ```bash
 docker compose down
 ```
+


### PR DESCRIPTION
* Add init-data to Trustee setup page as an option for setting kbs uri
* Add reference to advanced Trustee configurations in the docker compose setup

See commit messages for more info