### PR TITLE
docs: tweak to trustee install docs

### DIFF
--- a/content/en/docs/attestation/installation/docker.md
+++ b/content/en/docs/attestation/installation/docker.md
@@ -17,7 +17,7 @@ Trustee can be installed using Docker Compose.
 
 Clone the Trustee repo.
 ```bash
-git clone https://github.com/confidential-containers/trustee.git
+git clone https://github.com/confidential-containers/trustee.git && cd trustee
 ```
 
 Run Trustee.


### PR DESCRIPTION
The next command assumes that we're inside the trustee dir, so add a cd.