### PR TITLE
docs: document confidential emptyDir overhead

### DIFF
--- a/content/en/docs/features/protected-storage/confidential-emptydir.md
+++ b/content/en/docs/features/protected-storage/confidential-emptydir.md
@@ -38,8 +38,27 @@ volumeMounts:
       sizeLimit: 64Gi
 ```
 
-On the host, this volume will be backed by a sparse file.
-As such, host resource usage will initially be small.
+On the host, this volume will be backed by a sparse file. Data blocks are allocated as the volume
+is used, but creating the filesystem, encryption, and integrity metadata consumes some physical
+host storage immediately.
+
+{{% alert title="Sizing block-backed emptyDir volumes" color="warning" %}}
+Kata Containers does not currently use `emptyDir.sizeLimit` to size the block device presented to
+the guest. Instead, it sets the maximum size of the sparse backing image, and therefore the logical
+capacity of the guest block device, to the capacity of the host filesystem containing the volume.
+Kubelet still counts the physically allocated blocks against `sizeLimit`.
+
+With the current ext4 formatting options, initial filesystem metadata uses approximately 0.08% of
+the logical capacity (about 2.5 GB for 2.9 TB). Encryption and integrity added about 50 MB in the
+same test.
+
+On a large host filesystem, the initial metadata allocation can consume a significant part of a
+small `sizeLimit`, reducing the space available to the workload or causing the pod to be evicted
+before it writes data. Allow enough headroom in `sizeLimit` for this metadata, or place kubelet's
+volume data on a smaller dedicated filesystem. See the Kata Containers
+[storage limitations](https://github.com/kata-containers/kata-containers/blob/main/docs/Limitations.md#block-backed-kubernetes-emptydir-volumes)
+for current overhead estimates, implementation details, and tracked improvements.
+{{% /alert %}}
 
 {{% alert title="Note" color="note" %}}
 LUKS2 does not support discard/trim when integrity is enabled.


### PR DESCRIPTION
Block-backed confidential emptyDir volumes are sized using the capacity of the host filesystem rather than Kubernetes sizeLimit. On large filesystems, filesystem, encryption, and integrity metadata can consume enough space to trigger pod eviction.

Document the user-visible impact and current mitigations, and refer to the Kata Containers storage limitations for detailed overhead estimates and tracked improvements.