### PR TITLE
docs: document GCP Secret Manager resource backend

### DIFF
--- a/content/en/docs/attestation/resources/resource-backends.md
+++ b/content/en/docs/attestation/resources/resource-backends.md
@@ -55,7 +55,7 @@ A resource URI of `kbs:///repo/type/tag` is translated into the Secret Manager v
 and the latest enabled version is served, matching the behavior of the Aliyun KMS backend.
 Credentials are resolved via
 [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
-(ADC): the `GOOGLE_APPLICATION_CREDENTIALS` env var, `gcloud auth application-default login`,
+(ADC): the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, `gcloud auth application-default login`,
 or the GCE/GKE/Cloud Run metadata server (workload identity).
 This backend is read-only; writes and deletes return an error, so provision and rotate
 secrets via GCP APIs.

--- a/content/en/docs/attestation/resources/resource-backends.md
+++ b/content/en/docs/attestation/resources/resource-backends.md
@@ -42,6 +42,27 @@ One KBS can be configured with a specified KMS instance in `repository_config` f
 These materials can be found in KMS instance's [AAP](https://www.alibabacloud.com/help/en/kms/user-guide/manage-aaps?spm=a3c0i.23458820.2359477120.1.4fd96e9bmEFST4).
 When being accessed, a resource URI of `kbs:///repo/type/tag` will be translated into the generic secret with name `tag`. Hinting that `repo/type` field will be ignored.
 
+### Google Cloud Secret Manager
+
+[Google Cloud Secret Manager](https://cloud.google.com/secret-manager/docs/overview)
+can also work as the KBS resource storage backend.
+Build the KBS with the `gcp` feature (e.g. `cargo build --features gcp`).
+In the KBS config, add a resource plugin with `storage_backend_type = "gcp"` and the
+`project_id` that owns the secrets.
+Resources are stored as Secret Manager secrets and fetched via `AccessSecretVersion`.
+A resource URI of `kbs:///repo/type/tag` is translated into the Secret Manager version
+`projects/<project_id>/secrets/<tag>/versions/latest`; the `repo/type` portion is ignored
+and the latest enabled version is served, matching the behavior of the Aliyun KMS backend.
+Credentials are resolved via
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+(ADC): the `GOOGLE_APPLICATION_CREDENTIALS` env var, `gcloud auth application-default login`,
+or the GCE/GKE/Cloud Run metadata server (workload identity).
+This backend is read-only; writes and deletes return an error, so provision and rotate
+secrets via GCP APIs.
+For details, see the
+[resource storage backend documentation](https://github.com/confidential-containers/trustee/blob/main/kbs/docs/resource_storage_backend.md)
+in the Trustee repo.
+
 ### Pkcs11
 
 The Pkcs11 backend uses Pkcs11 to store plaintext resources


### PR DESCRIPTION
## What

Adds a **Google Cloud Secret Manager** section to the [Resource Backends](https://confidentialcontainers.org/docs/attestation/resources/resource-backends/) page, documenting the new backend introduced in confidential-containers/trustee#1469.

## Details

The new section covers:
- Building KBS with the `gcp` feature flag
- Configuration (`storage_backend_type = "gcp"` + `project_id`)
- URI translation: `kbs:///repo/type/tag` → `projects/<project_id>/secrets/<tag>/versions/latest` (with `repo/type` ignored, latest enabled version served)
- Credential resolution via Application Default Credentials (ADC)
- Read-only behavior
- A link to the upstream Trustee resource storage backend docs

It's placed right after the Aliyun KMS section to keep the cloud secret backends together, and matches the concise prose style of the existing backend entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSNL3cnKofW7WSLy3srQ5U