### PR TITLE
docs: Update AWS example

### DIFF
--- a/content/en/docs/examples/aws-simple.md
+++ b/content/en/docs/examples/aws-simple.md
@@ -298,6 +298,21 @@ providerConfigs:
 EOF
 ```
 
+### Install cert-manager
+
+CAA requires cert-manager to be installed. Unless you already have it
+installed deploy it via:
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --wait \
+  --timeout 5m
+```
+
 ### Deploy helm chart on the Kubernetes cluster
 
 1. Create namespace managed by Helm:

--- a/content/en/docs/examples/aws-simple.md
+++ b/content/en/docs/examples/aws-simple.md
@@ -131,7 +131,7 @@ aws ec2 authorize-security-group-ingress --group-id "$EKS_CLUSTER_SG" --protocol
 {{% tab header="Last Release" %}}
 
 ```bash
-export CAA_VERSION="0.17.0"
+export CAA_VERSION="0.22.0"
 curl -LO "https://github.com/confidential-containers/cloud-api-adaptor/archive/refs/tags/v${CAA_VERSION}.tar.gz"
 tar -xvzf "v${CAA_VERSION}.tar.gz"
 cd "cloud-api-adaptor-${CAA_VERSION}/src/cloud-api-adaptor/install/charts/peerpods"

--- a/content/en/docs/examples/aws-simple.md
+++ b/content/en/docs/examples/aws-simple.md
@@ -174,7 +174,7 @@ by running the following CLI:
 
 ```bash
 export PODVM_AMI_ID=$(aws ec2 describe-images \
-    --filters Name=name,Values="podvm-fedora-amd64-${CAA_VERSION//./-}" \
+    --filters Name=name,Values="podvm-ubuntu-amd64-${CAA_VERSION//./-}" \
     --query 'Images[*].[ImageId]' --output text)
 
 echo $PODVM_AMI_ID


### PR DESCRIPTION
The AWS example is a bit outdated. I tested the current 0.22.0 and with following changes it worked well (tested non-confidential only)