### PR TITLE
docs: replace admin private key with admin token

### DIFF
--- a/content/en/blog/2024/coco-without-confidential-hardware.md
+++ b/content/en/blog/2024/coco-without-confidential-hardware.md
@@ -333,7 +333,7 @@ Let’s add the to-be-fetched resource to the KBS first. Think of that resource 
 
 ```console
 $ echo "MySecretKey" > secret.txt
-$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --auth-private-key "$KBS_PRIVATE_KEY" set-resource --path default/secret/1 --resource-file secret.txt
+$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --admin-token-file "$KBS_ADMIN_TOKEN" set-resource --path default/secret/1 --resource-file secret.txt
 Set resource success
  resource: TXlTZWNyZXRLZXkK
 ```
@@ -409,7 +409,7 @@ The `GetResource` request to CDH is an attested operation. The policy in **resou
 Apply the resources_policy.rego policy to the KBS, then respin the coco-demo-04 pod, and you will see `MySecretKey` is now fetched:
 
 ```console
-$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --auth-private-key "$KBS_PRIVATE_KEY" set-resource-policy --policy-file resources_policy.rego
+$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --admin-token-file "$KBS_ADMIN_TOKEN" set-resource-policy --policy-file resources_policy.rego
 Set resource policy success
  policy: cGFja2FnZSBwb2xpY3kKCmRlZmF1bHQgYWxsb3cgPSBmYWxzZQoKYWxsb3cgewogICAgaW5wdXRbInRlZSJdID09ICJzYW1wbGUiCn0K
 $ kubectl apply -f coco-demo-04.yaml
@@ -599,7 +599,7 @@ The reason why it failed is because the decryption key wasn’t found in the KBS
 
 ```console
 $ echo "HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc=" | base64 -d > image_key.txt
-$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --auth-private-key "$KBS_PRIVATE_KEY" set-resource --path default/key/ssh-demo --resource-file image_key.txt
+$ ./kbs-client --url "http://$KBS_HOST:$KBS_PORT" config --admin-token-file "$KBS_ADMIN_TOKEN" set-resource --path default/key/ssh-demo --resource-file image_key.txt
 Set resource success
  resource: HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc=
 ```

--- a/content/en/docs/attestation/client-tool/_index.md
+++ b/content/en/docs/attestation/client-tool/_index.md
@@ -65,7 +65,7 @@ In general most commands will have the same form.
 Here is an example command that sets a resource in the KBS.
 ```bash
 kbs-client --url <url-of-kbs> config \
-    --auth-private-key <admin-private-key> set-resource \
+    --admin-token-file <admin-token-file> set-resource \
     --path <resource-name> --resource-file <path-to-resource-file>
 ```
 
@@ -76,11 +76,11 @@ Depending on how and where Trustee is deployed, the URL will be different.
 For example, if you use the docker compose deployment, the KBS URL
 will typically be the IP of your local node with port 8080.
 
-#### Private Key
+#### Admin Token
 
-All `kbs-client config` commands must take an `--auth-private-key` flag.
+All `kbs-client config` commands must take an `--admin-token-file` flag.
 Configuring the KBS is a privileged operation so the configuration endpoint
 must be protected.
-The admin private key is usually set before deploying Trustee.
-Refer to the installation guide for where your private key is stored,
+The admin token is usually set before deploying Trustee.
+Refer to the installation guide for where your admin token is stored,
 and point the client to it.

--- a/content/en/docs/attestation/policies/_index.md
+++ b/content/en/docs/attestation/policies/_index.md
@@ -51,14 +51,14 @@ Both policies use OPA.
 Both types of policies can be provisioned with the KBS Client.
 ```bash
 kbs-client --url <kbs-url> config \
-    --auth-private-key <admin-private-key> set-resource-policy \
+    --admin-token-file <admin-token-file> set-resource-policy \
     --policy-file <path-to-policy-file>
 ```
 
 The attestation service policy is set in a similar manner.
 ```bash
 kbs-client --url <kbs-url> config \
-    --auth-private-key <admin-private-key> set-attestation-policy \
+    --admin-token-file <admin-token-file> set-attestation-policy \
     --policy-file <path-to-policy-file>
 ```
 
@@ -73,7 +73,7 @@ The KBS Client has a few simple policies built into it.
 You can set one of these policies with a command like this.
 ```bash
 ./kbs-client --url <kbs-url>
-    config --auth-private-key <admin-private-key>
+    config --admin-token-file <admin-token-file>
     set-resource-policy --affirming
 ```
 

--- a/content/en/docs/attestation/reference-values/_index.md
+++ b/content/en/docs/attestation/reference-values/_index.md
@@ -29,7 +29,7 @@ the requests are proxied through the trusted admin interface.
 
 To set a reference value, use a command like this.
 ```bash
-./kbs-client config --auth-private-key <admin-private-key> set-sample-reference-value <rv-name> <rv-value>
+./kbs-client config --admin-token-file <admin-token-file> set-sample-reference-value <rv-name> <rv-value>
 ```
 
 By default, the reference value will be added as a list containing one string value.
@@ -44,7 +44,7 @@ use the RVPS Tool described below.
 
 To view reference values, you can use the following command.
 ```bash
-./kbs-client config --auth-private-key <admin-private-key> get-reference-values
+./kbs-client config --admin-token-file <admin-token-file> get-reference-values
 ```
 
 

--- a/content/en/docs/examples/nvidia-nim-confidential-gpu-attestation.md
+++ b/content/en/docs/examples/nvidia-nim-confidential-gpu-attestation.md
@@ -600,13 +600,13 @@ docker compose \
   ps
 ```
 
-Keep `KBS_URL`, the admin private key, and the KBS HTTPS certificate; later checkpoints use them to
+Keep `KBS_URL`, the admin token, and the KBS HTTPS certificate; later checkpoints use them to
 configure KBS resources and to build pod initdata:
 
 ```bash
-KBS_ADMIN_PRIVATE_KEY_FILE="${KBS_CONFIG_DIR}/private.key"
+KBS_ADMIN_TOKEN_FILE="${KBS_CONFIG_DIR}/admin-token"
 KBS_CERT_FILE="${KBS_CONFIG_DIR}/kbs-https.crt"
-test -s "${KBS_ADMIN_PRIVATE_KEY_FILE}"
+test -s "${KBS_ADMIN_TOKEN_FILE}"
 test -s "${KBS_CERT_FILE}"
 ```
 
@@ -647,7 +647,7 @@ printf 'checkpoint2-probe\n' > "${KBS_WORKDIR}/checkpoint2-probe.txt"
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/checkpoint2/probe \
   --resource-file "${KBS_WORKDIR}/checkpoint2-probe.txt"
@@ -656,16 +656,16 @@ printf 'checkpoint2-probe\n' > "${KBS_WORKDIR}/checkpoint2-probe.txt"
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   delete-resource \
   --path default/checkpoint2/probe
 ```
 
-Keep this shell, or save `KBS_CLIENT`, `KBS_WORKDIR`, `KBS_ADMIN_PRIVATE_KEY_FILE`,
+Keep this shell, or save `KBS_CLIENT`, `KBS_WORKDIR`, `KBS_ADMIN_TOKEN_FILE`,
 `KBS_CERT_FILE`, and `KBS_URL` somewhere private so they can be reused while working through the
 next checkpoints. Do not remove `KBS_WORKDIR`; it contains the Trustee source tree, Compose
 configuration, demo state, and generated tutorial files. Later `kbs-client` commands authenticate to
-KBS with the Compose-generated admin private key, so protect it as an administrator credential.
+KBS with the Compose-generated admin token, so protect it as an administrator credential.
 
 ## Checkpoint 3: Prepare the TEE NIM Manifest and Sealed Secret
 
@@ -1482,7 +1482,7 @@ echo base64-encoded credential material:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/credentials/nvcr \
   --resource-file "${KBS_WORKDIR}/nvcr-auth.json" \
@@ -1492,7 +1492,7 @@ echo base64-encoded credential material:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/ngc-api-key/instruct \
   --resource-file "${KBS_WORKDIR}/ngc-api-key-instruct" \
@@ -1502,7 +1502,7 @@ echo base64-encoded credential material:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/security-policy/nim \
   --resource-file "${KBS_WORKDIR}/nim-image-policy.json"
@@ -1511,7 +1511,7 @@ echo base64-encoded credential material:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/cosign-public-key/nim \
   --resource-file "${KBS_WORKDIR}/nvidia-cosign.pub"
@@ -1526,7 +1526,7 @@ referenced plaintext secret from KBS.
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource \
   --path default/signing-key/sealed-secret \
   --resource-file "${KBS_WORKDIR}/signing-key-public.jwk"
@@ -1539,7 +1539,7 @@ Seed the SNP reference values used by the default Trustee sample policy:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-sample-reference-value \
   snp_launch_measurement "${SNP_LAUNCH_MEASUREMENT}"
 
@@ -1547,7 +1547,7 @@ Seed the SNP reference values used by the default Trustee sample policy:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-sample-reference-value \
   --as-integer \
   snp_bootloader "${SNP_BOOTLOADER}"
@@ -1556,7 +1556,7 @@ Seed the SNP reference values used by the default Trustee sample policy:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-sample-reference-value \
   --as-integer \
   snp_microcode "${SNP_MICROCODE}"
@@ -1565,7 +1565,7 @@ Seed the SNP reference values used by the default Trustee sample policy:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-sample-reference-value \
   --as-integer \
   snp_snp_svn "${SNP_SNP_SVN}"
@@ -1574,7 +1574,7 @@ Seed the SNP reference values used by the default Trustee sample policy:
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-sample-reference-value \
   --as-integer \
   snp_tee_svn "${SNP_TEE_SVN}"
@@ -1614,7 +1614,7 @@ EOF
   --cert-file "${KBS_CERT_FILE}" \
   --url "${KBS_URL}" \
   config \
-  --auth-private-key "${KBS_ADMIN_PRIVATE_KEY_FILE}" \
+  --admin-token-file "${KBS_ADMIN_TOKEN_FILE}" \
   set-resource-policy \
   --policy-file "${KBS_WORKDIR}/nim-kbs-resource-policy.rego"
 ```

--- a/content/en/docs/features/sealed-secrets.md
+++ b/content/en/docs/features/sealed-secrets.md
@@ -153,7 +153,7 @@ Run the following command to add the secret to KBS storage:
 
 ```bash
 ./kbs-client --url <SCHEME>://<HOST>:<PORT> config \
-  --auth-private-key private.key \
+  --admin-token-file admin-token \
   set-resource \
   --resource-file ./my_secret \
   --path ${SIGNING_RESOURCE_URI}
@@ -220,7 +220,7 @@ Run the following command to add the public key to KBS storage:
 
 ```bash
 ./kbs-client --url <SCHEME>://<HOST>:<PORT> config \
-  --auth-private-key kbs.key \
+  --admin-token-file admin-token \
   set-resource \
   --resource-file ./public_jwk.json \
   --path ${SIGNING_KID_KBS_URI}

--- a/content/en/docs/features/signed-images.md
+++ b/content/en/docs/features/signed-images.md
@@ -244,7 +244,7 @@ Run the following command to add the public key to KBS storage:
 
 ```bash
 ./kbs-client --url <SCHEME>://<HOST>:<PORT> config \
-  --auth-private-key private.key \
+  --admin-token-file admin-token \
   set-resource \
   --resource-file cosign.pub \
   --path default/sig-public-key/test
@@ -325,7 +325,7 @@ Run the following command to add the security policy to KBS storage:
 
 ```bash
 ./kbs-client --url <SCHEME>://<HOST>:<PORT> config \
-  --auth-private-key private.key \
+  --admin-token-file admin-token \
   set-resource \
   --resource-file ./security-policy.json \
   --path default/security-policy/test


### PR DESCRIPTION
Our latest release replaces the admin private key with an admin token. Update various docs to reflect this.
