### PR TITLE
language: add zh-CN language for overview page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,4 +8,4 @@ weight: 20
 ---
 
 Confidential Containers is an open source project that brings confidential computing to Cloud Native environments, leveraging hardware technology to protect complex workloads.
-Confidential Containers is a CNCF sandbox project.
+Confidential Containers is a CNCF incubating project.

--- a/content/en/docs/overview/_index.md
+++ b/content/en/docs/overview/_index.md
@@ -49,6 +49,7 @@ The following platforms are supported.
 | -------- | ----- | ----- |
 | SNP | Azure ||
 | TDX | Azure ||
+| TDX | Alibaba Cloud ||
 | Secure Execution | IBM ||
 | None | AWS | Under development |
 | SNP | GCP ||
@@ -70,6 +71,7 @@ which is able to attest the following platforms:
 | IBM Secure Execution |
 | ARM CCA | 
 | Hygon CSV |
+| Hygon DCU |
 | NVIDIA GPU |
 
 Trustee can be used with Confidential Containers or to attest standalone confidential guests.

--- a/content/zh-cn/_index.md
+++ b/content/zh-cn/_index.md
@@ -1,0 +1,63 @@
+---
+title: Confidential Containers
+---
+
+{{< blocks/cover image_anchor="top" height="full" >}}
+<div class="position-relative">
+<div class="d-flex flex-column h-100 inter-cover">
+<div class="row justify-content-around">
+<div class="col-12 col-xl-7">
+<div class="mb-4">
+<img style="width:20%" src="/confidential-containers-project-logo-square.png" alt="Confidential containers"/>
+</div>
+<div class="cover-text-big">
+在可信执行环境中
+<br>
+部署云原生应用
+</div>
+<div class="inter-light mt-4">
+利用机密计算与硬件隔离，保护<strong>正在运行</strong>的容器。
+</div>
+<div class="p-5">
+<a class="btn btn-lg btn-primary me-3 mb-4" href="/zh-cn/docs/overview/">
+查看概览<i class="fas fa-arrow-alt-circle-right ms-2"></i>
+</a>
+<a class="btn btn-lg btn-secondary me-3 mb-4" href="/docs/overview/">
+English Overview<i class="fas fa-arrow-alt-circle-right ms-2"></i>
+</a>
+</div>
+</div>
+</div>
+</div>
+</div>
+{{< /blocks/cover >}}
+
+{{% blocks/section type="row" %}}
+
+{{% blocks/feature icon="fa-brain" title="Confidential AI" %}}
+在使用云端硬件做模型训练时，也能保护敏感模型和数据隐私。既可以在云上部署自己的模型，也可以创建一个安全环境让其他人运行他们的模型。
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-shield" title="受监管行业" %}}
+利用技术保障保护银行和医疗健康数据安全，并以硬件机制强化合规。
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-link" title="保障供应链安全" %}}
+在封闭环境中构建应用和软件包，并以硬件可信根作为供应链的信任基础。
+{{% /blocks/feature %}}
+{{% /blocks/section %}}
+
+{{% blocks/section type="row" %}}
+{{% blocks/feature icon="fa-code" title="开源" %}}
+Confidential Containers 自诞生伊始就是多家公司共同协作的成果，各方携手共建关键组件，并通过透明、可审计的方式保障安全。
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-handshake" title="厂商中立" %}}
+Confidential Containers 通过在 Pod 级别标准化机密计算，将硬件平台和云服务整合到统一框架中，为安全应用提供支持。
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-building-columns" title="CNCF 孵化项目" %}}
+Confidential Containers 是 [CNCF](https://www.cncf.io/) 旗下的孵化项目（Incubating Project），与众多云原生项目保持紧密联系。
+{{% /blocks/feature %}}
+{{% /blocks/section %}}
+

--- a/content/zh-cn/docs/_index.md
+++ b/content/zh-cn/docs/_index.md
@@ -1,0 +1,11 @@
+---
+title: 文档
+linkTitle: 文档
+menu:
+  main:
+    weight: 20
+weight: 20
+---
+
+Confidential Containers 是一个开源项目，将机密计算引入云原生环境，利用硬件技术保护复杂工作负载。
+Confidential Containers 是 CNCF Sandbox 项目。

--- a/content/zh-cn/docs/_index.md
+++ b/content/zh-cn/docs/_index.md
@@ -8,4 +8,4 @@ weight: 20
 ---
 
 Confidential Containers 是一个开源项目，将机密计算引入云原生环境，利用硬件技术保护复杂工作负载。
-Confidential Containers 是 CNCF Sandbox 项目。
+Confidential Containers 是 CNCF Incubating 项目。

--- a/content/zh-cn/docs/overview/_index.md
+++ b/content/zh-cn/docs/overview/_index.md
@@ -1,0 +1,75 @@
+---
+title: 概览
+description: Confidential Containers 概览
+weight: 1
+---
+
+## 什么是 Confidential Containers（CoCo）项目？
+
+Confidential Containers（CoCo）通过将 Pod 运行在机密虚拟机（Confidential Virtual Machine）中，
+让云原生工作负载在几乎无需修改的情况下利用机密计算硬件提供的安全能力。
+
+Confidential Containers 将机密计算保护能力扩展到复杂工作负载场景。
+借助 Confidential Containers，敏感工作负载即便运行在不受信任的主机环境（untrusted hosts）上，
+也能够抵御来自已遭入侵或恶意的用户、软件和管理员的攻击。
+
+Confidential Containers 提供一个 **工作负载部署**、**远程证明（Remote Attestation）** 以及 **密钥/机密信息（Keys/Secrets）分发** 的端到端框架。
+
+## Confidential Containers 支持哪些硬件？
+
+在裸金属环境下，Confidential Containers 支持以下平台：
+
+| 平台 | 支持远程证明（Remote Attestation） |
+| -------- | -------------------- |
+| Intel TDX | 是 |
+| AMD SEV-SNP | 是 |
+| IBM Secure Execution | 是 |
+
+### 硬件加速器（Accelerators）
+
+| 硬件加速器 | 单设备透传 | 多设备透传 |
+| --- | --- | --- |
+| Hygon DCU | 是 | 否 |
+| NVIDIA Hopper | 是 | Protected PCIe |
+| NVIDIA RTX Pro 6000 BSE | 是 | 否 |
+| NVIDIA Blackwell | 是 | 是 |
+
+NVIDIA 多设备透传要求将主机上的全部 GPU 分配给同一个 Pod。
+NVIDIA Protected PCIe 还要求在 Pod 中列出 NVIDIA NVLink 交换机。
+
+### 云平台
+
+还可以借助`cloud-api-adaptor`在**云环境**中部署Confidential Containers。
+
+目前支持以下平台。
+
+| 平台 | 云 | 备注 |
+| -------- | ----- | ----- |
+| SNP | Azure ||
+| TDX | Azure ||
+| TDX | 阿里云 ||
+| Secure Execution | IBM ||
+| None | AWS | 开发中 |
+| SNP | GCP ||
+| TDX | GCP | 开发中 |
+| None | LibVirt | 用于本地测试 |
+
+### 远程证明（Attestation）
+
+Confidential Containers 提供了一个名为 Trustee 的远程证明与密钥管理引擎，可为以下平台提供远程证明：
+
+| 平台 |
+| -------- |
+| AMD SEV-SNP |
+| Intel TDX |
+| Intel SGX |
+| AMD SEV-SNP with Azure vTPM |
+| Intel TDX with Azure vTPM |
+| IBM Secure Execution |
+| ARM CCA |
+| Hygon CSV |
+| Hygon DCU |
+| NVIDIA GPU |
+
+Trustee 既可以与 Confidential Containers 配合使用，也可以用于对独立运行的机密虚拟机（即非 CoCo 场景）进行远程证明。
+更多信息请参见“远程证明（Attestation）”章节。

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -7,6 +7,8 @@ copyright: >-
 # Language settings
 contentDir: content/en
 defaultContentLanguage: en
+defaultContentLanguageInSubdir: false
+enableMissingTranslationPlaceholders: false
 languageCode: en-us
 languages:
   en:
@@ -16,6 +18,13 @@ languages:
     params:
       title: Confidential Containers
       description: Cloud Native Confidential Computing; Run Confidential Containers on Kubernetes
+  zh-cn:
+    languageName: 简体中文
+    contentDir: content/zh-cn
+    weight: 2
+    params:
+      title: Confidential Containers
+      description: 云原生机密计算；在 Kubernetes 上运行机密容器
 
 enableRobotsTXT: true
 enableEmoji: true

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -1,0 +1,9 @@
+# Site-level overrides / additions for Docsy UI strings.
+# Theme already ships most zh-cn strings; these keys are missing upstream.
+
+# Table of contents
+[toc_on_this_page]
+other = "本页内容"
+
+[toc_top_of_page]
+other = "回到顶部"


### PR DESCRIPTION
This commit only adds zh-CN language for main page and the overview page.

I assume few people can understand Chinese, so hopefully this PR can help me to get feedback upon only the codes.

The basic principle of translation for me is to remain strictly faithful to the logic of the original English. Also to prevent ambiguity I added some more context in the words. Also, to keep read fluence, use natural expression within the Chinese context.

If this kind of PR is acceptable, I will finish other parts in later PRs.

Related #195 