### PR TITLE
docs: clarify pgpu count vs multi-GPU passthrough on Blackwell

### DIFF
--- a/content/en/docs/examples/nvidia-gpu-examples.md
+++ b/content/en/docs/examples/nvidia-gpu-examples.md
@@ -61,6 +61,8 @@ spec:
 
 ## 2. Blackwell: multi-GPU passthrough (MPT)
 
+This assigns all of the host's GPUs to one pod so they act as a single confidential group, rather than as separate GPUs that each run on their own. The `nvidia.com/pgpu` value is only the number of GPUs you request, not the mode. An RTX Pro 6000 can use a value of 8, for example, and still run as eight separate single-GPU passthroughs rather than multi-GPU passthrough.
+
 Use the same pod as above, but change the resource section:
 
 ```yaml


### PR DESCRIPTION
## What

I added a short clarifier to the Blackwell multi-GPU passthrough (MPT) example in `content/en/docs/examples/nvidia-gpu-examples.md`, noting that `nvidia.com/pgpu` is only the number of GPUs you request, not the passthrough mode and that a value greater than one is not multi-GPU passthrough on its own.

## Why

The existing MPT example only bumps `nvidia.com/pgpu` from 1 to 8, which reads as if the count is what selects the mode. It tripped me up in practice: I attached 8 GPUs to a single pod on an RTX Pro 6000 and saw all of them in nvidia-smi while still not being MPT. Those were eight independent single-GPU passthroughs, since real MPT depends on the GPUs actually operating as one confidential group, not just on the requested count. I used the RTX Pro 6000 with `pgpu: 8` as the concrete example.